### PR TITLE
Fix ORCID links

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -34,8 +34,8 @@ authors:
 - family-names: Ahadzie
   given-names: Banky
   email: bahadzie@gmail.com
-repository-code: https://github.com/bahadzie/numberizeR
-url: https://bahadzie.github.io/numberizeR/index.html
+repository-code: https://github.com/epiverse-trace/numberize
+url: https://github.com/epiverse-trace/numberize
 contact:
 - family-names: Ahadzie
   given-names: Banky
@@ -58,7 +58,7 @@ references:
   - family-names: Hester
     given-names: Jim
     email: james.hester@rstudio.com
-  year: '2023'
+  year: '2024'
 - type: software
   title: testthat
   abstract: 'testthat: Unit Testing for R'
@@ -69,5 +69,5 @@ references:
   - family-names: Wickham
     given-names: Hadley
     email: hadley@posit.co
-  year: '2023'
+  year: '2024'
   version: '>= 3.0.0'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,15 +4,15 @@ Version: 0.0.1
 Authors@R: c(
     person("Avinash", "Laddha", , "avinash@data.org", role = "aut"),
     person("James M.", "Azam", , "james.azam@lshtm.ac.uk", role = "aut",
-           comment = c(ORCID = "https://orcid.org/0000-0001-5782-7330")),
+           comment = c(ORCID = "0000-0001-5782-7330")),
     person("Jaime A.", "Pavlich-Mariscal", , "jpavlich@javeriana.edu.co", role = "ctb",
-           comment = c(ORCID = "https://orcid.org/0000-0002-3892-6680")),
+           comment = c(ORCID = "0000-0002-3892-6680")),
     person("Pratik", "Gupte", , "pratik.gupte@lshtm.ac.uk", role = "aut",
-           comment = c(ORCID = "https://orcid.org/0000-0001-5294-7819")),
+           comment = c(ORCID = "0000-0001-5294-7819")),
     person("Joshua W.", "Lambert", , "joshua.lambert@lshtm.ac.uk", role = "aut",
            comment = c(ORCID = "0000-0001-5218-3046")),
     person("Hugo", "Gruson", , "hugo.gruson+R@normalesup.org", role = "aut",
-           comment = c(ORCID = "https://orcid.org/0000-0002-4094-1476")),
+           comment = c(ORCID = "0000-0002-4094-1476")),
     person("Banky", "Ahadzie", , "bahadzie@gmail.com", role = c("aut", "cre"))
   )
 Description: Converts numbers written as English, French or Spanish words


### PR DESCRIPTION
This PR fixes the ORCID links for the `pkgdown` page. See also upstream change to the template - https://github.com/epiverse-trace/packagetemplate/pull/126